### PR TITLE
Resize resources for finops-sample

### DIFF
--- a/config/samples/resources.yaml
+++ b/config/samples/resources.yaml
@@ -19,8 +19,8 @@ spec:
         image: nginx:latest
         resources:
           requests:
-            cpu: "100m"
-            memory: "128Mi"
+            cpu: "25m"
+            memory: "262144k"
           limits:
-            cpu: "500m"
-            memory: "256Mi"
+
+            memory: "262144k"


### PR DESCRIPTION
This PR was created by the FinOps Operator to update resource requirements for default/finops-sample.

Update resource recommendations (CPU: 25m, Memory: 262144k)